### PR TITLE
Children support, internal state to store values & provide values of previous questions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -302,14 +302,15 @@ class EurekaForm extends React.Component {
                 ...this.state,
                 wasSubmitted: true
             }, () => {
-                const values = [];
+                const values = {};
 
                 // Disable all inputs
                 this.state.questions.forEach(question => {
                     const questionInput = question.querySelector('input, textarea, select');
+                    const key = questionInput.getAttribute("id")
                     questionInput.setAttribute("disabled", true);
 
-                    values.push(questionInput.value);
+                    values[key] = questionInput.value;
                 });
                 
                 // Remove next button

--- a/src/index.js
+++ b/src/index.js
@@ -333,17 +333,20 @@ class EurekaForm extends React.Component {
         <form id={this.props.id} className={customClass + "simform"} ref={formRef => this.formRef = formRef}>
             <div className="simform-inner">
                 <ol className="questions">
-                    {this.props.questions.map((question, i) =>
-                        <li key={`eureka-question-${i}`}>
-                            <span>
-                                <label htmlFor={`eureka-question-${i}`}>
-                                    {question.title}
-                                </label>
-                            </span>
+                    {this.props.questions.map((question, i) => {
+                         const key = question.key || `eureka-question-${i}`
+                         return (
+                             <li key={key}>
+                                 <span>
+                                     <label htmlFor={key}>
+                                         {question.title}
+                                     </label>
+                                 </span>
 
-                            <input id={`eureka-question-${i}`} name={`eureka-question-${i}`} type={question.inputType || "text"} />
-                        </li>
-                    )}
+                                 <input id={key} name={key} type={question.inputType || "text"} />
+                             </li>
+                         )
+                    })}
                 </ol>
                 
                 <button className="submit" type="submit">Send answers</button>

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ class EurekaForm extends React.Component {
         this.state = {
             current: 0,
             questions: [],
+            values: {},
             wasSubmitted: false
         };
     }
@@ -180,6 +181,7 @@ class EurekaForm extends React.Component {
 		// current question
 		const currentQuestion = this.state.questions[this.state.current];
         currentQuestion.querySelector('input, textarea, select').blur();
+        this._setValue(currentQuestion)
 
         this.setState({
             ...this.state,
@@ -296,28 +298,32 @@ class EurekaForm extends React.Component {
 		this.error.classList.remove('show');
     }
     
+    _setValue(question) {
+        const questionInput = question.querySelector('input, textarea, select');
+        questionInput.setAttribute("disabled", true);
+        const key = questionInput.getAttribute("id")
+        const newState = {
+            ...this.state,
+            values: {
+                ...this.state.values,
+                [key]: questionInput.value
+            }
+        }
+        this.setState(newState)
+        this.props.onUpdate(newState)
+    }
+
     _submit() {
         if (!this.state.wasSubmitted) {
             this.setState({
                 ...this.state,
                 wasSubmitted: true
             }, () => {
-                const values = {};
-
-                // Disable all inputs
-                this.state.questions.forEach(question => {
-                    const questionInput = question.querySelector('input, textarea, select');
-                    const key = questionInput.getAttribute("id")
-                    questionInput.setAttribute("disabled", true);
-
-                    values[key] = questionInput.value;
-                });
-                
                 // Remove next button
                 this.ctrlNext.style.display = "none";
 
                 // Call the custom onSubmit function
-                this.props.onSubmit(this.formRef, values);
+                this.props.onSubmit(this.formRef, this.state.values);
             });
         }
 	}

--- a/src/index.js
+++ b/src/index.js
@@ -339,7 +339,7 @@ class EurekaForm extends React.Component {
         <form id={this.props.id} className={customClass + "simform"} ref={formRef => this.formRef = formRef}>
             <div className="simform-inner">
                 <ol className="questions">
-                    {this.props.questions.map((question, i) => {
+                    {this.props.questions && this.props.questions.map((question, i) => {
                          const key = question.key || `eureka-question-${i}`
                          return (
                              <li key={key}>
@@ -350,6 +350,20 @@ class EurekaForm extends React.Component {
                                  </span>
 
                                  <input id={key} name={key} type={question.inputType || "text"} />
+                             </li>
+                         )
+                    })}
+                    {this.props.children && React.Children.map(this.props.children, (child, i) => {
+                         const key = child.props.type || `eureka-question-${i}`
+                         return (
+                             <li key={key}>
+                                 <span>
+                                     <label htmlFor={key}>
+                                         {child}
+                                     </label>
+                                 </span>
+
+                                 <input id={key} name={key} type={child.props.type || "text"} />
                              </li>
                          )
                     })}
@@ -377,6 +391,10 @@ class EurekaForm extends React.Component {
         </form>
       )
     }
+}
+
+EurekaForm.defaultProps = {
+    onUpdate: function () {}
 }
 
 module.exports = { EurekaForm };

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ class EurekaForm extends React.Component {
 			if (!input.checkValidity()) {
 				// Optionally, set a custom HTML5 valiation message
 				// comment or remove this line to use the browser default message
-                input.setCustomValidity('Whoops, that\'s not an email address!');
+                //input.setCustomValidity('Whoops, that\'s not an email address!');
                 
 				// display the HTML5 error message
                 this._showError(input.validationMessage);


### PR DESCRIPTION
first of all, thanks for a great package !

The goal of this series is essentially to change the API so you can write: 
```js
class FormWrapper extends React.Component {
  constructor () {
    super()
    this.state = {
      current: -1,
      values: {}
    }
  }

  render () {
    const {values, current} = this.state
    const remaining = <Number value={3 - current - 1} />

    return (
      <div>
// access the current question to know how much's remaining
// 3 is hardcoded because it's still not filled on the first question, can be fixed
        <h1>{remaining}/3</h1>
        <EurekaForm autoFocus
          onSubmit={doStuff} onUpdate={(state) => this.setState(state)}>
          <span type='name'>what's your name</span>
//here we use answers for the previous questions, if you don't name your values (with the type prop)
//they will appear as eureka-option-#n
//we don't use key as it's not passed down, but if we want to separate type and key (i.e. type: email, key: yourProfessionalEmail we could use type/id)
          <span type='email'>hello {values.name}, and your email ?</span>
          <span type='tel'>phone</span>
        </EurekaForm>
      </div>
    )
  }
}
```

to do this we first:
- change results form an array to an object, with named properties
- change the logic so we collect values each time a question is done
- add an `onUpdate()` callback that broadcasts back the state on each change (should it be `onChange()` ?)

note that you can still pass a `questions` array, even though it's a bit redundant, and that if you pass childs *and* `questions`, both will be displayed, `questions` first.

**Changelog:**
- use answers from previous questions
- add/remove questions depending on the former answer
- create UI elements that respond to the answering state: progressbar, counters, etc...

cheers,